### PR TITLE
feat: allow custom gateway url

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,16 @@ CLUSTER_PASSWORD="<boop>"
 GITHUB_TOKEN="<needs repo status scope>"
 ```
 
+You can optionally overrider the following
+
+```sh
+# Multiaddr for the ipfs cluster to pin your site to
+CLUSTER_HOST="/dnsaddr/cluster.ipfs.io"
+
+# URL for the gateway to use for the site preview url
+IPFS_GATEWAY="https://ipfs.io"
+```
+
 ## Contribute
 
 Feel free to dive in! [Open an issue](https://github.com/ipfs-shipyard/ipfs-action/issues/new) or submit PRs.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,6 +6,7 @@ if [[ $# -eq 0 ]] ; then
   echo 'CLUSTER_USER="who" \'
   echo 'CLUSTER_PASSWORD="_secret_" \'
   echo 'CLUSTER_HOST="/dnsaddr/cluster.ipfs.io" \'
+  echo 'IPFS_GATEWAY="https://ipfs.io"'
   echo 'GITHUB_REPOSITORY="ipfs-shipyard/ipld-explorer" \'
   echo 'GITHUB_SHA="bf3aae3bc98666fbf459b03ab2d87a97505bfab0" \'
   echo 'GITHUB_TOKEN="_secret" \'
@@ -16,6 +17,7 @@ fi
 INPUT_DIR=$1
 PIN_NAME="https://github.com/$GITHUB_REPOSITORY/commits/$GITHUB_SHA"
 HOST=${CLUSTER_HOST:-"/dnsaddr/cluster.ipfs.io"}
+GATEWAY_URL=${IPFS_GATEWAY:-"https://ipfs.io"}
 
 update_github_status () {
   # only try and update the satus if we have a github token
@@ -45,11 +47,12 @@ update_github_status "pending" "Pinnning to IPFS cluster" "https://ipfs.io/"
 root_cid=$(ipfs-cluster-ctl \
     --host $HOST \
     --basic-auth $CLUSTER_USER:$CLUSTER_PASSWORD \
-    add --quieter \
+    add \
+    --quieter \
     --name "$PIN_NAME" \
     --recursive $INPUT_DIR )
 
-preview_url=https://cluster.ipfs.io/ipfs/$root_cid
+preview_url="$GATEWAY_URL/ipfs/$root_cid"
 
 update_github_status "success" "Website added to IPFS" "$preview_url"
 


### PR DESCRIPTION
User can pass IPFS_GATEWAY env var to specify the origin to use for
IPFS preview URLs.

License: MIT
Signed-off-by: Oli Evans <oli@tableflip.io>