### PR TITLE
Fix interpolation of env vars when calling docker action with input args

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,11 @@ This action uses https://github.com/ipfs-shipyard/ipfs-dns-deploy to do the work
 **Required** Multiaddr for the IPFS Cluster. 
 _Default_ `/dnsaddr/cluster.ipfs.io`
 
+### `ipfs_gateway`
+
+**Required** URL for the IPFS gateway to use in the preview link
+_Default_ `https://ipfs.io`
+
 ## Outputs
 
 ### `cid`

--- a/action.yml
+++ b/action.yml
@@ -19,6 +19,10 @@ inputs:
     description: 'Multiaddr for the IPFS Cluster'
     default: '/dnsaddr/cluster.ipfs.io'
     required: true
+  ipfs_gateway:
+    description: 'IPFS Gateway to use for preview url'
+    default: 'https://ipfs.io'
+    required: true
 outputs:
   cid:
     description: 'The IPFS Content ID for the directory'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -e
 
+echo "Pinning $1 to $CLUSTER_HOST"
+
 if [[ $# -eq 0 ]] ; then
   echo 'Usage:'
   echo 'CLUSTER_USER="who" \'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,7 +10,7 @@ set -e
 #   exit 1
 # fi
 
-# interpolate env vars in the path, see: 
+
 # INPUT_DIR=$(sh -c "echo $1")
 # CLUSTER_USER=$2
 # CLUSTER_PASSWORD=$3
@@ -18,7 +18,8 @@ set -e
 # IPFS_GATEWAY=$5
 PIN_NAME="https://github.com/$GITHUB_REPOSITORY/commits/$GITHUB_SHA"
 
-INPUT_DIR="$INPUT_PATH_TO_ADD"
+# interpolate env vars in the $INPUT_PATH_TO_ADD, see: https://docs.github.com/en/actions/creating-actions/dockerfile-support-for-github-actions#entrypoint
+INPUT_DIR=$(sh -c "echo $INPUT_PATH_TO_ADD")
 echo "Pinning $INPUT_DIR to $INPUT_CLUSTER_HOST"
 echo "GITHUB_WORKSPACE is $GITHUB_WORKSPACE"
 echo "GITHUB_REPOSITORY is $GITHUB_REPOSITORY"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -24,7 +24,7 @@ echo "Pinning $INPUT_DIR to $INPUT_CLUSTER_HOST"
 echo "GITHUB_WORKSPACE is $GITHUB_WORKSPACE"
 echo "GITHUB_REPOSITORY is $GITHUB_REPOSITORY"
 echo "pwd $(pwd)"
-ls -la "$1"
+ls -la "$INPUT_DIR"
 
 update_github_status () {
   # only try and update the satus if we have a github token

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,6 +2,7 @@
 set -e
 
 echo "Pinning $1 to $CLUSTER_HOST"
+ls -la "$1"
 
 if [[ $# -eq 0 ]] ; then
   echo 'Usage:'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -47,6 +47,17 @@ update_github_status () {
 
 update_github_status "pending" "Pinnning to IPFS cluster" "https://ipfs.io/"
 
+# check command works
+ipfs-cluster-ctl
+
+ipfs-cluster-ctl \
+    --host $HOST \
+    --basic-auth $CLUSTER_USER:$CLUSTER_PASSWORD \
+    add \
+    --quieter \
+    --name "$PIN_NAME" \
+    --recursive $INPUT_DIR
+
 # pin to cluster
 root_cid=$(ipfs-cluster-ctl \
     --host $HOST \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,6 +2,7 @@
 set -e
 
 echo "Pinning $1 to $CLUSTER_HOST"
+echo "GITHUB_WORKSPACE is $GITHUB_WORKSPACE"
 echo "pwd $(pwd)"
 ls -la "$1"
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,24 +1,25 @@
 #!/usr/bin/env bash
 set -e
 
-if [[ $# -lt 5 ]] ; then
-  echo 'Usage:'
-  echo 'GITHUB_REPOSITORY="ipfs-shipyard/ipld-explorer" \'
-  echo 'GITHUB_SHA="bf3aae3bc98666fbf459b03ab2d87a97505bfab0" \'
-  echo 'GITHUB_TOKEN="_secret" \'
-  echo './entrypoint.sh <input root dir to pin recursivly> <cluster_user> <cluster_password> <cluster_host> <ipfs_gateway>'
-  exit 1
-fi
+# if [[ $# -lt 5 ]] ; then
+#   echo 'Usage:'
+#   echo 'GITHUB_REPOSITORY="ipfs-shipyard/ipld-explorer" \'
+#   echo 'GITHUB_SHA="bf3aae3bc98666fbf459b03ab2d87a97505bfab0" \'
+#   echo 'GITHUB_TOKEN="_secret" \'
+#   echo './entrypoint.sh <input root dir to pin recursivly> <cluster_user> <cluster_password> <cluster_host> <ipfs_gateway>'
+#   exit 1
+# fi
 
 # interpolate env vars in the path, see: 
-INPUT_DIR=$(sh -c "echo $1")
-CLUSTER_USER=$2
-CLUSTER_PASSWORD=$3
-CLUSTER_HOST=$4
-IPFS_GATEWAY=$5
+# INPUT_DIR=$(sh -c "echo $1")
+# CLUSTER_USER=$2
+# CLUSTER_PASSWORD=$3
+# CLUSTER_HOST=$4
+# IPFS_GATEWAY=$5
 PIN_NAME="https://github.com/$GITHUB_REPOSITORY/commits/$GITHUB_SHA"
 
-echo "Pinning $INPUT_DIR to $CLUSTER_HOST"
+INPUT_DIR="$INPUT_PATH_TO_ADD"
+echo "Pinning $INPUT_DIR to $INPUT_CLUSTER_HOST"
 echo "GITHUB_WORKSPACE is $GITHUB_WORKSPACE"
 echo "GITHUB_REPOSITORY is $GITHUB_REPOSITORY"
 echo "pwd $(pwd)"
@@ -46,29 +47,29 @@ update_github_status () {
   curl --silent --output /dev/null -X POST -H "Authorization: token $GITHUB_TOKEN" -H 'Content-Type: application/json' --data "$params" $STATUS_API_URL
 }
 
-update_github_status "pending" "Pinnning to IPFS cluster" "$IPFS_GATEWAY"
+update_github_status "pending" "Pinnning to IPFS cluster" "$INPUT_IPFS_GATEWAY"
 
 # check command works
 ipfs-cluster-ctl
 
-ipfs-cluster-ctl \
-    --host $CLUSTER_HOST \
-    --basic-auth $CLUSTER_USER:$CLUSTER_PASSWORD \
-    add \
-    --quieter \
-    --name "$PIN_NAME" \
-    --recursive $INPUT_DIR
+# ipfs-cluster-ctl \
+#     --host $INPUT_CLUSTER_HOST \
+#     --basic-auth $INPUT_CLUSTER_USER:$INPUT_CLUSTER_PASSWORD \
+#     add \
+#     --quieter \
+#     --name "$PIN_NAME" \
+#     --recursive $INPUT_DIR
 
 # pin to cluster
 root_cid=$(ipfs-cluster-ctl \
-    --host $HOST \
-    --basic-auth $CLUSTER_USER:$CLUSTER_PASSWORD \
+    --host "$INPUT_CLUSTER_HOST" \
+    --basic-auth "$INPUT_CLUSTER_USER:$INPUT_CLUSTER_PASSWORD" \
     add \
     --quieter \
     --name "$PIN_NAME" \
-    --recursive $INPUT_DIR )
+    --recursive "$INPUT_DIR" )
 
-preview_url="$IPFS_GATEWAY/ipfs/$root_cid"
+preview_url="$INPUT_IPFS_GATEWAY/ipfs/$root_cid"
 
 update_github_status "success" "Website added to IPFS" "$preview_url"
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,6 +2,7 @@
 set -e
 
 echo "Pinning $1 to $CLUSTER_HOST"
+echo "pwd $(pwd)"
 ls -la "$1"
 
 if [[ $# -eq 0 ]] ; then


### PR DESCRIPTION
This seems like a foot gun that is gonna waste a lot of folks time. If you try an pass an input argument to a docker action as an input, env vars do not get interpolated, so you can't pass a path as `$GITHUB_WORKSPACE/path/to/thing` without manually re-interpolating it in the entrypoint.sh... it's described in the docs, but it's not obvious, and seems like exactly what you'd want to do.

See: https://docs.github.com/en/actions/creating-actions/dockerfile-support-for-github-actions#entrypoint