### PR TITLE
feat: use subdomain gateway for preview url

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,36 @@
 # IPFS GitHub Action
 
-Publish websites to IPFS as part of a github action workflow. This action pins a directory to IPFS by using the ipfs-cluster-ctl command to pin it to a remote IPFS Cluster.
+Publish websites to IPFS as part of a github action workflow. This action pins a directory to IPFS by using the ipfs-cluster-ctl command to pin it to a remote IPFS Cluster. It sets the IPFS URL as a status on the commit that triggered the action, allowing easy previewing of rendered static sites on the dweb.
+
+**NOTE:** You need to provide **credentials to an IPFS cluster** instance that you have permission to pin to, in order to make use of this action.
 
 This action uses https://github.com/ipfs-shipyard/ipfs-dns-deploy to do the work.
 
-**NOTE** You need to provide credentials to an IPFS cluster instance that you have permission to pin to, in order to make use of this action.
-
 ![screenshot](screenshot.png)
+
+## Usage
+
+Use this action from a workflow that build out your static site to a directory. In this example we ask ipfs-github-action to pin the `public` dir in the current workspace to cluster.ipfs.io
+
+```yaml
+- uses: ipfs-shipyard/ipfs-github-action@v2
+  id: ipfs
+  with:
+    path_to_add: public
+    cluster_host: /dnsaddr/cluster.ipfs.io
+    cluster_user: ${{ secrets.CLUSTER_USER }}
+    cluster_password: ${{ secrets.CLUSTER_PASSWORD }}
+  env:
+    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+# "bafkreicysg23kiwv34eg2d7qweipxwosdo2py4ldv42nbauguluen5v6am"
+- run: echo /ipfs/${{ steps.ipfs.outputs.cid }}
+
+# https://bafkreicysg23kiwv34eg2d7qweipxwosdo2py4ldv42nbauguluen5v6am.ipfs.dweb.link
+- run: echo ${{ steps.ipfs.outputs.url }}
+```
+
+Check the [filecoin spec website workflow](https://github.com/filecoin-project/specs/blob/71f37208a1f4f56b33ea307d7cbdb4b06996b115/.github/workflows/main.yml) for a complete example out in the wild that also updates a DNSLink record when with the new cid when a commit changes the production branch.
 
 
 ## Inputs
@@ -25,20 +49,34 @@ This action uses https://github.com/ipfs-shipyard/ipfs-dns-deploy to do the work
 
 ### `cluster_host`
 
-**Required** Multiaddr for the IPFS Cluster. 
+**Required** Multiaddr for the IPFS Cluster. - see: https://cluster.ipfs.io/
 _Default_ `/dnsaddr/cluster.ipfs.io`
 
 ### `ipfs_gateway`
 
-**Required** IPFS subdomain gateway to use for preview url
+**Required** IPFS subdomain gateway to use for preview url - see: https://docs.ipfs.io/concepts/ipfs-gateway
 _Default_ `dweb.link`
+
+If you'd prefer to use `/ipfs/<cid>` style preview urls, then v1 of this action is the one for you! 
+
+see: https://github.com/ipfs-shipyard/ipfs-github-action/releases/tag/v1.0.0
+
 
 ## Outputs
 
 ### `cid`
 
-The IPFS content identifier for the directory on IPFS. You fetch your site via IPFS at `https://<cid>.ipfs.dweb.link`
+The IPFS content identifier for the directory on IPFS. 
+e.g. `bafkreicysg23kiwv34eg2d7qweipxwosdo2py4ldv42nbauguluen5v6am`
 
+More info on CIDs: https://docs.ipfs.io/concepts/content-addressing/
+
+### `url`
+
+The URL for the IPFS gateway to preview the content over https.
+e.g. https://bafkreicysg23kiwv34eg2d7qweipxwosdo2py4ldv42nbauguluen5v6am.ipfs.dweb.link
+
+More info on IPFS Gateways: https://docs.ipfs.io/concepts/ipfs-gateway
 
 ## Contribute
 

--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ _Default_ `/dnsaddr/cluster.ipfs.io`
 
 ### `ipfs_gateway`
 
-**Required** URL for the IPFS gateway to use in the preview link
-_Default_ `https://ipfs.io`
+**Required** IPFS subdomain gateway to use for preview url
+_Default_ `dweb.link`
 
 ## Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -20,8 +20,8 @@ inputs:
     default: '/dnsaddr/cluster.ipfs.io'
     required: true
   ipfs_gateway:
-    description: 'IPFS Gateway to use for preview url'
-    default: 'https://ipfs.io'
+    description: 'IPFS subdomain gateway to use for preview url'
+    default: 'dweb.link'
     required: true
 outputs:
   cid:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -50,3 +50,5 @@ update_github_status "success" "Website added to IPFS" "$preview_url"
 echo "Pinned to IPFS - $preview_url"
 
 echo "::set-output name=cid::$root_cid"
+
+echo "::set-output name=url::$preview_url"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -38,10 +38,12 @@ root_cid=$(ipfs-cluster-ctl \
     --basic-auth "$INPUT_CLUSTER_USER:$INPUT_CLUSTER_PASSWORD" \
     add \
     --quieter \
+    --local \
+    --cid-version 1 \
     --name "$PIN_NAME" \
     --recursive "$INPUT_DIR" )
 
-preview_url="$INPUT_IPFS_GATEWAY/ipfs/$root_cid"
+preview_url="https://$root_cid.ipfs.$INPUT_IPFS_GATEWAY"
 
 update_github_status "success" "Website added to IPFS" "$preview_url"
 


### PR DESCRIPTION
ipfs cid-in-subdomain gateways are preferred now as they preserve the origin isolation of each site by using the cid as part of the domain. Each root is isloated from every other root. It means your site is mounted on / rather than /ipfs so root-relative urls will still work too, which is a big deal.

Also adds the gateway url as an action output, for nice nice.