### PR TITLE
fix: send https url as target_url on status

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM olizilla/ipfs-dns-deploy:latest
+FROM olizilla/ipfs-dns-deploy:1.8
 
 COPY "entrypoint.sh" "/entrypoint.sh"
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ If you'd prefer to use `/ipfs/<cid>` style preview urls, then v1 of this action 
 
 see: https://github.com/ipfs-shipyard/ipfs-github-action/releases/tag/v1.0.0
 
+- Must be the hostname without a scheme prefix. e.g dweb.link not https://dweb.link
+- Links in commit status messages will be prefixed with https. http is not supported; GitHub prevents the `target_url` property from using http urls.
 
 ## Outputs
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -31,7 +31,7 @@ update_github_status () {
   curl -X POST -H "Authorization: Bearer $GITHUB_TOKEN" -H 'Content-Type: application/json' --data "$params" $STATUS_API_URL
 }
 
-update_github_status "pending" "Pinnning to IPFS cluster" "$INPUT_IPFS_GATEWAY"
+update_github_status "pending" "Pinnning to IPFS cluster" "https://$INPUT_IPFS_GATEWAY"
 
 # pin to cluster
 root_cid=$(ipfs-cluster-ctl \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -28,7 +28,7 @@ update_github_status () {
     --arg context "$CONTEXT" \
     '{ state: $state, target_url: $target_url, description: $description, context: $context }' )
 
-  curl --silent --show-error -X POST -H "Authorization: Bearer $GITHUB_TOKEN" -H 'Content-Type: application/json' --data "$params" $STATUS_API_URL
+  curl --output /dev/null --silent --show-error -X POST -H "Authorization: Bearer $GITHUB_TOKEN" -H 'Content-Type: application/json' --data "$params" $STATUS_API_URL
 }
 
 update_github_status "pending" "Pinnning to IPFS cluster" "https://$INPUT_IPFS_GATEWAY"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,7 +2,7 @@
 set -e
 
 # Interpolate env vars in the $INPUT_PATH_TO_ADD, see: https://docs.github.com/en/actions/creating-actions/dockerfile-support-for-github-actions#entrypoint
-# This handles situation where user provides path to add as $GITHUB_WORKSPACE/some/path
+# This handles situation where user provides path to add as $GITHUB_WORKSPACE/some/path
 INPUT_DIR=$(sh -c "echo $INPUT_PATH_TO_ADD")
 PIN_NAME="https://github.com/$GITHUB_REPOSITORY/commits/$GITHUB_SHA"
 
@@ -27,7 +27,7 @@ update_github_status () {
     --arg context "$CONTEXT" \
     '{ state: $state, target_url: $target_url, description: $description, context: $context }' )
 
-  curl --silent --output /dev/null -X POST -H "Authorization: token $GITHUB_TOKEN" -H 'Content-Type: application/json' --data "$params" $STATUS_API_URL
+  curl --silent --output /dev/null -X POST -H "Authorization: Bearer $GITHUB_TOKEN" -H 'Content-Type: application/json' --data "$params" $STATUS_API_URL
 }
 
 update_github_status "pending" "Pinnning to IPFS cluster" "$INPUT_IPFS_GATEWAY"
@@ -39,13 +39,14 @@ root_cid=$(ipfs-cluster-ctl \
     add \
     --quieter \
     --local \
+    --wait \
     --cid-version 1 \
     --name "$PIN_NAME" \
     --recursive "$INPUT_DIR" )
 
 preview_url="https://$root_cid.ipfs.$INPUT_IPFS_GATEWAY"
 
-update_github_status "success" "Website added to IPFS" "$preview_url"
+update_github_status "success" "View on IPFS" "$preview_url"
 
 echo "Pinned to IPFS - $preview_url"
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,6 +11,7 @@ echo "Pinning $INPUT_DIR to $INPUT_CLUSTER_HOST"
 update_github_status () {
   # only try and update the satus if we have a github token
   if [ -z "$GITHUB_TOKEN" ] ; then
+    echo "Not setting status. No GITHUB_TOKEN set"
     return 0
   fi
 
@@ -27,7 +28,7 @@ update_github_status () {
     --arg context "$CONTEXT" \
     '{ state: $state, target_url: $target_url, description: $description, context: $context }' )
 
-  curl --silent --output /dev/null -X POST -H "Authorization: Bearer $GITHUB_TOKEN" -H 'Content-Type: application/json' --data "$params" $STATUS_API_URL
+  curl -X POST -H "Authorization: Bearer $GITHUB_TOKEN" -H 'Content-Type: application/json' --data "$params" $STATUS_API_URL
 }
 
 update_github_status "pending" "Pinnning to IPFS cluster" "$INPUT_IPFS_GATEWAY"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -28,7 +28,7 @@ update_github_status () {
     --arg context "$CONTEXT" \
     '{ state: $state, target_url: $target_url, description: $description, context: $context }' )
 
-  curl -X POST -H "Authorization: Bearer $GITHUB_TOKEN" -H 'Content-Type: application/json' --data "$params" $STATUS_API_URL
+  curl --silent --show-error -X POST -H "Authorization: Bearer $GITHUB_TOKEN" -H 'Content-Type: application/json' --data "$params" $STATUS_API_URL
 }
 
 update_github_status "pending" "Pinnning to IPFS cluster" "https://$INPUT_IPFS_GATEWAY"


### PR DESCRIPTION
- switch auth to use Barer instead of token as per https://docs.github.com/en/actions/reference/authentication-in-a-workflow#example-2-calling-the-rest-api
- add --wait flag to ensure we wait until cluster has all the blocks

License: (Apache-2.0 AND MIT)
Signed-off-by: Oli Evans <oli@tableflip.io>