### PR TITLE
feat: pin content paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Check the [filecoin spec website workflow](https://github.com/filecoin-project/s
 
 ### `path_to_add`
 
-**Required** The path the root directory of your static website or other content that you want to publish to IPFS.
+**Required** The path the root directory of your static website or other content that you want to publish to IPFS. If the path is absolute content path (eg. `/ipfs/{cid}`) then action will fetch and pin using IPFS.
 
 ### `cluster_user`
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -56,6 +56,12 @@ else
         --recursive "$INPUT_DIR" )
 fi
 
+# error when error or missing or empty CID
+if [[ $root_cid == *error* ]] || [[ -z "${root_cid// }" ]] ; then
+    >&2 echo "Error: CID returned by the cluster is >$root_cid<"
+    exit 1
+fi
+
 preview_url="https://$root_cid.ipfs.$INPUT_IPFS_GATEWAY"
 
 update_github_status "success" "View on IPFS" "$preview_url"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -35,13 +35,14 @@ update_github_status "pending" "Pinnning to IPFS cluster" "https://$INPUT_IPFS_G
 
 if [[ $INPUT_DIR == /ipfs/* ]] || [[ $INPUT_DIR == /ipns/* ]] ; then
     # if path is already an absolute content path just pin over IPFS
-    root_cid=$(ipfs-cluster-ctl \
+    ipfs-cluster-ctl \
         --host "$INPUT_CLUSTER_HOST" \
         --basic-auth "$INPUT_CLUSTER_USER:$INPUT_CLUSTER_PASSWORD" \
         pin add \
         --wait \
         --name "$PIN_NAME" \
-        "$INPUT_DIR" | head -1 | cut -d: -f1)
+        "$INPUT_DIR" | tee /tmp/pin-log
+    root_cid=$(head -1 /tmp/pin-log | cut -d: -f1)
 else
     # add dir to cluster
     root_cid=$(ipfs-cluster-ctl \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -33,17 +33,28 @@ update_github_status () {
 
 update_github_status "pending" "Pinnning to IPFS cluster" "https://$INPUT_IPFS_GATEWAY"
 
-# pin to cluster
-root_cid=$(ipfs-cluster-ctl \
-    --host "$INPUT_CLUSTER_HOST" \
-    --basic-auth "$INPUT_CLUSTER_USER:$INPUT_CLUSTER_PASSWORD" \
-    add \
-    --quieter \
-    --local \
-    --wait \
-    --cid-version 1 \
-    --name "$PIN_NAME" \
-    --recursive "$INPUT_DIR" )
+if [[ $INPUT_DIR == /ipfs/* ]] || [[ $INPUT_DIR == /ipns/* ]] ; then
+    # if path is already an absolute content path just pin over IPFS
+    root_cid=$(ipfs-cluster-ctl \
+        --host "$INPUT_CLUSTER_HOST" \
+        --basic-auth "$INPUT_CLUSTER_USER:$INPUT_CLUSTER_PASSWORD" \
+        pin add \
+        --wait \
+        --name "$PIN_NAME" \
+        "$INPUT_DIR" | head -1 | cut -d: -f1)
+else
+    # add dir to cluster
+    root_cid=$(ipfs-cluster-ctl \
+        --host "$INPUT_CLUSTER_HOST" \
+        --basic-auth "$INPUT_CLUSTER_USER:$INPUT_CLUSTER_PASSWORD" \
+        add \
+        --quieter \
+        --local \
+        --wait \
+        --cid-version 1 \
+        --name "$PIN_NAME" \
+        --recursive "$INPUT_DIR" )
+fi
 
 preview_url="https://$root_cid.ipfs.$INPUT_IPFS_GATEWAY"
 


### PR DESCRIPTION
This feature detects absolute paths starting with `/ipfs/` or `/ipns/` and pins them instead of adding a local directory.

This enables use on CI without the need for having  entire dataset locally (eg. dist.ipfs.io – see https://github.com/ipfs/distributions/pull/362)

